### PR TITLE
Add workaround to fix shared lib generation with Visual Studio

### DIFF
--- a/cmake.patch
+++ b/cmake.patch
@@ -2,7 +2,18 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 004a2a9..bd87433 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -88,5 +88,6 @@ if(GLAD_INSTALL)
+@@ -76,6 +76,10 @@
+   set_target_properties(glad PROPERTIES LINKER_LANGUAGE ${GLAD_LINKER_LANGUAGE})
+ endif()
+ 
++if(CMAKE_GENERATOR MATCHES "Visual Studio" AND BUILD_SHARED_LIBS)
++    set_target_properties(glad PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
++endif()
++
+ # Export
+ if(GLAD_EXPORT)
+   set(GLAD_LIBRARIES glad PARENT_SCOPE)
+@@ -88,5 +92,6 @@ if(GLAD_INSTALL) 
      install(DIRECTORY ${GLAD_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_PREFIX})
    endif()
    install(TARGETS glad EXPORT glad-targets

--- a/cmake.patch
+++ b/cmake.patch
@@ -6,7 +6,7 @@ index 004a2a9..bd87433 100644
    set_target_properties(glad PROPERTIES LINKER_LANGUAGE ${GLAD_LINKER_LANGUAGE})
  endif()
  
-+if(CMAKE_GENERATOR MATCHES "Visual Studio" AND BUILD_SHARED_LIBS)
++if (MSVC AND BUILD_SHARED_LIBS)
 +    set_target_properties(glad PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 +endif()
 +

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,12 +77,7 @@ class GladConan(ConanFile):
         cmake.configure(build_folder=self.build_subfolder)
         cmake.install()
         
-        self.copy(pattern="*.a", dst="lib", src=".", keep_path=False)
-        self.copy(pattern="*.lib", dst="lib", src=".", keep_path=False)
         self.copy(pattern="*.dll", dst="bin", src=".", keep_path=False)
-        self.copy(pattern="*.so*", dst="lib", src=".", keep_path=False)
-        self.copy(pattern="*.dylib*", dst="lib", src=".", keep_path=False)
-        self.copy(pattern="*.pdb", dst="bin", src=".", keep_path=False)
         
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,6 +77,13 @@ class GladConan(ConanFile):
         cmake.configure(build_folder=self.build_subfolder)
         cmake.install()
         
+        self.copy(pattern="*.a", dst="lib", src=".", keep_path=False)
+        self.copy(pattern="*.lib", dst="lib", src=".", keep_path=False)
+        self.copy(pattern="*.dll", dst="bin", src=".", keep_path=False)
+        self.copy(pattern="*.so*", dst="lib", src=".", keep_path=False)
+        self.copy(pattern="*.dylib*", dst="lib", src=".", keep_path=False)
+        self.copy(pattern="*.pdb", dst="bin", src=".", keep_path=False)
+        
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":


### PR DESCRIPTION
This fixes shared libraries not generating correctly with VS2017 when shared=True, causing linker errors. The dll did not exist in the package bin folder.